### PR TITLE
Branch protection rules

### DIFF
--- a/.github/config/branch_protection.yml
+++ b/.github/config/branch_protection.yml
@@ -1,0 +1,6 @@
+- branch: main
+  protection:
+    required_pull_request_reviews:
+      required_approving_review_count: 1
+    allow_force_pushes: false
+    allow_deletions: false


### PR DESCRIPTION
- Avoids direct commit to the main branch
- Enforces at least one approval from a peer dev